### PR TITLE
Add link to play demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 This is the repository for the Space Pirates game demo for Babylon.js 5.0 Release.
 It contains assets and code so you can clone, learn and do modifications.
 
+# Playtest the demo
+
+https://spacepirates.babylonjs.com/
+
 # How to build and test ?
 
 In root folder:


### PR DESCRIPTION
For some reason, the link to play the demo was never advertised in the repository and only in the src/build files, which is perfectly understandable due to the Babylon.js 5.0 deadlines. This is a minor PR meant to respectfully resolve that oversight.